### PR TITLE
Feat: proxy authentication

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Arjun.swagger-viewer"
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,25 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f1667b8320afa80d69d8bbe40830df2c8a06003d86f73d8e003b2c48df416d"
-dependencies = [
- "async-trait",
- "json5",
- "lazy_static",
- "nom",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde",
- "serde_json",
- "toml",
- "yaml-rust",
-]
-
-[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,12 +703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +730,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "envconfig"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea81cc7e21f55a9d9b1efb6816904978d0bfbe31a50347cb24b2e75564bcac9b"
+dependencies = [
+ "envconfig_derive",
+]
+
+[[package]]
+name = "envconfig_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfca278e5f84b45519acaaff758ebfa01f18e96998bc24b8f1b722dd804b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1242,17 +1237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "jsonwebtoken"
 version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,12 +1281,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1410,7 +1388,7 @@ dependencies = [
 name = "money-balancer"
 version = "1.2.0"
 dependencies = [
- "config",
+ "envconfig",
  "futures",
  "jsonwebtoken",
  "migration",
@@ -1579,16 +1557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list",
- "hashbrown",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,12 +1646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
 name = "pear"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,50 +1682,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "pest"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
-dependencies = [
- "once_cell",
- "pest",
- "sha1",
-]
 
 [[package]]
 name = "pin-project"
@@ -2142,17 +2060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64",
- "bitflags",
- "serde",
-]
-
-[[package]]
 name = "rust-embed"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,16 +2091,6 @@ checksum = "c1669d81dfabd1b5f8e2856b8bbe146c6192b0ba22162edc738ac0a5de18f054"
 dependencies = [
  "sha2 0.10.5",
  "walkdir",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -2499,17 +2396,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.3",
 ]
 
 [[package]]
@@ -3015,12 +2901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
 name = "uncased"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,15 +3261,6 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pwhash = "1"
 jsonwebtoken = "8"
 serial_test = "0.9.0"
 rust-embed = "6.4.1"
-config = "0.13.2"
+envconfig = "0.10.0"
 
 [dependencies.migration]
 path = "./migration"

--- a/README.md
+++ b/README.md
@@ -45,16 +45,39 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - JWT_SECRET=some_super_secret_secret
+      - MONEYBALANCER_JWT_SECRET=some_super_secret_secret
 ```
 
 Using `docker`:
 
 ```bash
-docker run -p8000:8000 -e JWT_SECRET=some_super_secret_secret -v $(pwd)/data:/data ghcr.io/dorianim/money-balancer
+docker run -p8000:8000 -e MONEYBALANCER_JWT_SECRET=some_super_secret_secret -v $(pwd)/data:/data ghcr.io/dorianim/money-balancer
 ```
 
 You can then access money-balancer on [`http://localhost:8000`](http://localhost:8000). The API documentation can be found at [`http://localhost:8000/api/v1`](http://localhost:8000/api/v1).
+
+# Config options
+
+- `MONEYBALANCER_JWT_SECRET`: a random value for the JWT signature
+
+### Authentication
+
+##### Local
+
+- `MONEYBALANCER_AUTH_LOCAL_ENABLED`: enable local username/password authentication
+
+##### Proxy
+
+Proxy authentication can be used with services like [authelia](https://www.authelia.com/) and [authentik](https://goauthentik.io)
+
+- `MONEYBALANCER_AUTH_PROXY_ENABLED`: enable proxy authentication
+- `MONEYBALANCER_AUTH_PROXY_HEADERS_USERNAME`: header containing the username (e.g. `X-authentik-username`)
+- `MONEYBALANCER_AUTH_PROXY_HEADERS_NICKNAME`: header containing the nickname (e.g. `X-authentik-name`)
+
+If you want to use another sign on method, you may only protect these routes:
+
+- `/api/v1/auth/proxy`
+- `/#/login/proxy`
 
 # How debts are split up:
 

--- a/client/src/components/ExpandMoreButton.tsx
+++ b/client/src/components/ExpandMoreButton.tsx
@@ -5,7 +5,7 @@ interface ExpandMoreProps extends IconButtonProps {
 }
 
 export const ExpandMoreButton = styled((props: ExpandMoreProps) => {
-  const { expand, ...other } = props;
+  const { ...other } = props;
   return <IconButton {...other} />;
 })(({ theme, expand }) => ({
   transform: !expand ? 'rotate(0deg)' : 'rotate(180deg)',

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -1,0 +1,52 @@
+import { LoadingButton } from '@mui/lab';
+import { Grid, TextField } from '@mui/material';
+import { FieldValues, useForm } from 'react-hook-form';
+
+export default function LoginForm(props: {
+  onSubmit: (data: FieldValues) => void;
+  loading: boolean;
+}) {
+  const { onSubmit, loading } = props;
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <TextField
+            label='Username'
+            disabled={loading}
+            error={errors.username !== undefined}
+            {...register('username', { required: true })}
+            fullWidth
+          ></TextField>
+        </Grid>
+
+        <Grid item xs={12}>
+          <TextField
+            type={'password'}
+            label='Password'
+            disabled={loading}
+            error={errors.password !== undefined}
+            {...register('password', { required: true })}
+            fullWidth
+          ></TextField>
+        </Grid>
+
+        <Grid item xs={12}>
+          <LoadingButton
+            loading={loading}
+            variant='contained'
+            type='submit'
+            fullWidth
+          >
+            Login
+          </LoadingButton>
+        </Grid>
+      </Grid>
+    </form>
+  );
+}

--- a/client/src/components/TransactionCard.tsx
+++ b/client/src/components/TransactionCard.tsx
@@ -7,7 +7,6 @@ import {
   CardHeader,
   Chip,
   Collapse,
-  IconButton,
   List,
   ListItem,
   ListItemText,

--- a/client/src/components/TransactionHistory.tsx
+++ b/client/src/components/TransactionHistory.tsx
@@ -1,17 +1,7 @@
-import { ChevronRight, ExpandMore } from '@mui/icons-material';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  Grid,
-  IconButton,
-  Typography,
-} from '@mui/material';
+import { Grid } from '@mui/material';
 import { useContext } from 'react';
 import { Context } from '../data/Context';
 import { Transaction, GroupMember } from '../data/Types';
-import { ExpandMoreButton } from './ExpandMoreButton';
 import TransactionCard from './TransactionCard';
 
 export default function TransactionHistory(params: {

--- a/client/src/data/MoneyBalancerApi.tsx
+++ b/client/src/data/MoneyBalancerApi.tsx
@@ -1,5 +1,11 @@
 import { ErrorData } from './Context';
-import { Debt, Group, Transaction, User } from './Types';
+import {
+  AvailableAuthenticationProviders,
+  Debt,
+  Group,
+  Transaction,
+  User,
+} from './Types';
 
 export const URL =
   !process.env.NODE_ENV || process.env.NODE_ENV === 'development'
@@ -78,6 +84,21 @@ export class MoneyBalancerApi {
 
   async logout() {
     this._setToken('');
+  }
+
+  async getAvailableAuthenticationProviders(): Promise<
+    AvailableAuthenticationProviders | undefined
+  > {
+    const r = await this._fetch('/auth', {
+      method: 'GET',
+    });
+
+    if (!r || (await this._error(r, 200))) {
+      return undefined;
+    }
+
+    const json = await r.json();
+    return json;
   }
 
   async localLogin(username: string, password: string) {

--- a/client/src/data/MoneyBalancerApi.tsx
+++ b/client/src/data/MoneyBalancerApi.tsx
@@ -80,13 +80,27 @@ export class MoneyBalancerApi {
     this._setToken('');
   }
 
-  async login(username: string, password: string) {
+  async localLogin(username: string, password: string) {
     const r = await this._fetch('/user/token', {
       method: 'POST',
       body: JSON.stringify({
         username: username,
         password: password,
       }),
+    });
+
+    if (!r || (await this._error(r, 200))) {
+      return false;
+    }
+
+    const json = await r.json();
+    this._setToken(json.token);
+    return true;
+  }
+
+  async proxyLogin() {
+    const r = await this._fetch('/auth/proxy', {
+      method: 'POST',
     });
 
     if (!r || (await this._error(r, 200))) {

--- a/client/src/data/Types.tsx
+++ b/client/src/data/Types.tsx
@@ -31,3 +31,12 @@ export interface Debt {
   amount: number;
   was_split_unequally: boolean;
 }
+
+export interface AvailableAuthenticationProviders {
+  local: {
+    enabled: boolean;
+  };
+  proxy: {
+    enabled: boolean;
+  };
+}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -30,9 +30,17 @@ export default function LoginPage() {
   const loadAvailableProviders = async () => {
     const availableProviders = await api.getAvailableAuthenticationProviders();
     setAvailableProviders(availableProviders);
+
+    console.log(availableProviders);
+    if (
+      !availableProviders?.local.enabled &&
+      availableProviders?.proxy.enabled
+    ) {
+      loginUsingProxy();
+    }
   };
 
-  const onSubmit = async (data: FieldValues) => {
+  const loginUsingLocal = async (data: FieldValues) => {
     setLoading(true);
     const loginResult = await api.localLogin(data.username, data.password);
     if (!loginResult) {
@@ -53,6 +61,10 @@ export default function LoginPage() {
     navigate(loginRedirectUrl, { replace: true });
   };
 
+  const loginUsingProxy = () => {
+    window.location.replace(`${window.location.href}/proxy`);
+  };
+
   return (
     <>
       <Grid container spacing={2}>
@@ -60,26 +72,25 @@ export default function LoginPage() {
           <CollapsableAlert></CollapsableAlert>
         </Grid>
 
-        {availableProviders?.local && (
+        {availableProviders?.local.enabled && (
           <Grid item xs={12}>
-            <LoginForm onSubmit={onSubmit} loading={loading} />
+            <LoginForm onSubmit={loginUsingLocal} loading={loading} />
           </Grid>
         )}
 
-        {availableProviders?.local && availableProviders?.proxy && (
-          <Grid item xs={12}>
-            <Divider>Or</Divider>
-          </Grid>
-        )}
+        {availableProviders?.local.enabled &&
+          availableProviders?.proxy.enabled && (
+            <Grid item xs={12}>
+              <Divider>Or</Divider>
+            </Grid>
+          )}
 
-        {availableProviders?.proxy && (
+        {availableProviders?.proxy.enabled && (
           <Grid item xs={12}>
             <Button
               variant='contained'
               disabled={loading}
-              onClick={() =>
-                window.location.replace(`${window.location.href}/proxy`)
-              }
+              onClick={loginUsingProxy}
               fullWidth
             >
               Login using SSO

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -106,20 +106,24 @@ export default function LoginPage() {
           </Grid>
         )}
 
-        <Grid item xs={12}>
-          <Divider>Or</Divider>
-        </Grid>
+        {availableProviders?.local.enabled && (
+          <>
+            <Grid item xs={12}>
+              <Divider>Or</Divider>
+            </Grid>
 
-        <Grid item xs={12}>
-          <Button
-            disabled={loading}
-            variant='outlined'
-            onClick={() => navigate('/registration')}
-            fullWidth
-          >
-            Register
-          </Button>
-        </Grid>
+            <Grid item xs={12}>
+              <Button
+                disabled={loading}
+                variant='outlined'
+                onClick={() => navigate('/registration')}
+                fullWidth
+              >
+                Register
+              </Button>
+            </Grid>
+          </>
+        )}
       </Grid>
     </>
   );

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -29,7 +29,7 @@ export default function LoginPage() {
 
   const onSubmit = async (data: FieldValues) => {
     setLoading(true);
-    const loginResult = await api.login(data.username, data.password);
+    const loginResult = await api.localLogin(data.username, data.password);
     if (!loginResult) {
       setLoading(false);
       return;

--- a/client/src/pages/ProxyLoginPage.tsx
+++ b/client/src/pages/ProxyLoginPage.tsx
@@ -1,0 +1,57 @@
+import { CircularProgress, Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import { useContext, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Context } from '../data/Context';
+
+export default function ProxyLoginPage() {
+  const { setTitle, setGoBackToUrl, loginRedirectUrl, api } =
+    useContext(Context);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (api.loggedIn()) {
+      navigate('/');
+      return;
+    }
+
+    setTitle('Proxy login ...');
+    setGoBackToUrl(undefined);
+
+    proxyLogin();
+  }, []);
+
+  const proxyLogin = async () => {
+    const loginResult = await api.proxyLogin();
+
+    if (!loginResult) {
+      navigate('/login');
+      return;
+    }
+
+    const userData = await api.getUser();
+    if (!userData) {
+      navigate('/login');
+      return;
+    }
+
+    navigate(loginRedirectUrl, { replace: true });
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '80vh',
+      }}
+    >
+      <Box sx={{ textAlign: 'center' }}>
+        <CircularProgress></CircularProgress>
+        <Typography>Logging you in...</Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/client/src/pages/RegistrationPage.tsx
+++ b/client/src/pages/RegistrationPage.tsx
@@ -40,7 +40,7 @@ export default function RegistrationPage() {
       return;
     }
 
-    const loginResult = await api.login(data.username, data.password);
+    const loginResult = await api.localLogin(data.username, data.password);
     if (!loginResult) {
       setLoading(false);
       navigate('/login');

--- a/client/src/utils/Routing.tsx
+++ b/client/src/utils/Routing.tsx
@@ -6,6 +6,7 @@ import PageTemplate from './PageTemplate';
 import GroupPage from '../pages/GroupPage';
 import GroupJoinPage from '../pages/GroupJoinPage';
 import RegistrationPage from '../pages/RegistrationPage';
+import ProxyLoginPage from '../pages/ProxyLoginPage';
 
 /**
  *
@@ -19,6 +20,7 @@ export default function Routing() {
         <Routes>
           <Route path='/' element={<GroupListPage />} />
           <Route path='/login' element={<LoginPage />}></Route>
+          <Route path='/login/proxy' element={<ProxyLoginPage />}></Route>
           <Route path='/registration' element={<RegistrationPage />}></Route>
           <Route path='/group/:groupId' element={<GroupPage />}></Route>
           <Route

--- a/src/guards/authentication.rs
+++ b/src/guards/authentication.rs
@@ -1,84 +1,38 @@
 use crate::services;
-use crate::services::configuration::ConfigurationService;
+use crate::services::authentication::{AuthenticationError, AuthenticationService};
 use crate::services::user::UserService;
-use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 use rocket::http::Status;
 use rocket::outcome::Outcome;
 use rocket::request::{self, FromRequest, Request};
-use rocket::serde::{Deserialize, Serialize};
-
-#[derive(Debug)]
-pub enum JwtError {
-    InvalidToken,
-    MissingToken,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct JwtClaims {
-    id: String,
-    iss: String,
-    exp: usize,
-}
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for services::user::User {
-    type Error = JwtError;
+    type Error = AuthenticationError;
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         let user_service = request.rocket().state::<UserService>().unwrap();
-        let configuration_service = request.rocket().state::<ConfigurationService>().unwrap();
+        let authentication_service = request.rocket().state::<AuthenticationService>().unwrap();
         let tokens: Vec<_> = request.headers().get("authorization").collect();
 
         if tokens.len() != 1 {
-            return Outcome::Failure((Status::Unauthorized, JwtError::MissingToken));
+            return Outcome::Failure((Status::Unauthorized, AuthenticationError::MissingToken));
         }
 
         let token = tokens.get(0).unwrap().to_string().replace("Bearer ", "");
 
-        let claims = validate_jwt(token, configuration_service.jwt_secret()).await;
+        let claims = authentication_service.validate_jwt(token).await;
 
         if let Err(e) = claims {
             println!("   >> Error validating token: {}", e);
-            return Outcome::Failure((Status::Unauthorized, JwtError::InvalidToken));
+            return Outcome::Failure((Status::Unauthorized, AuthenticationError::InvalidToken));
         }
 
         let user = user_service.get_user_by_id(claims.unwrap().id).await;
 
         if let Err(_) = user {
-            return Outcome::Failure((Status::Unauthorized, JwtError::InvalidToken));
+            return Outcome::Failure((Status::Unauthorized, AuthenticationError::InvalidToken));
         }
 
         Outcome::Success(user.unwrap())
     }
-}
-
-pub async fn validate_jwt(
-    token: String,
-    jwt_secret: String,
-) -> Result<JwtClaims, jsonwebtoken::errors::Error> {
-    let mut validation = Validation::new(Algorithm::HS256);
-    validation.set_issuer(&["de:itsblue:money-balancer"]);
-    validation.validate_exp = false;
-
-    let token = jsonwebtoken::decode::<JwtClaims>(
-        &token,
-        &DecodingKey::from_secret(jwt_secret.as_bytes()),
-        &validation,
-    )?;
-
-    Ok(token.claims)
-}
-
-pub fn generate_jwt(user_id: String, jwt_secret: String) -> String {
-    let jwt = jsonwebtoken::encode(
-        &jsonwebtoken::Header::default(),
-        &JwtClaims {
-            id: user_id.to_owned(),
-            iss: "de:itsblue:money-balancer".to_string(),
-            exp: 0,
-        },
-        &jsonwebtoken::EncodingKey::from_secret(jwt_secret.as_bytes()),
-    );
-
-    jwt.unwrap()
 }

--- a/src/guards/headers.rs
+++ b/src/guards/headers.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use rocket::outcome::Outcome;
+use rocket::request::{self, FromRequest, Request};
+
+pub struct RequestHeaders {
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub enum HeaderError {}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for RequestHeaders {
+    type Error = HeaderError;
+
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+        let headers = request
+            .headers()
+            .clone()
+            .into_iter()
+            .map(|header| (header.name.to_string(), header.value.to_string()))
+            .collect::<HashMap<String, String>>();
+
+        Outcome::Success(RequestHeaders {
+            headers: headers.to_owned(),
+        })
+    }
+}

--- a/src/guards/mod.rs
+++ b/src/guards/mod.rs
@@ -1,1 +1,2 @@
 pub mod authentication;
+pub mod headers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,6 @@ pub fn build_rocket(db: DatabaseConnection) -> Rocket<Build> {
     let group_service = services::group::GroupService::new(db.clone());
 
     let authentication_service = Arc::new(services::authentication::AuthenticationService::new(
-        db.clone(),
         configuration_service.clone(),
         user_service.clone(),
     ));
@@ -108,4 +107,5 @@ pub fn build_rocket(db: DatabaseConnection) -> Rocket<Build> {
         .mount("/api/v1", routes::swagger::routes())
         .mount("/api/v1/user", routes::user::routes())
         .mount("/api/v1/group", routes::group::routes())
+        .mount("/api/v1/auth", routes::auth::routes())
 }

--- a/src/resources/api/openapi.yaml
+++ b/src/resources/api/openapi.yaml
@@ -82,6 +82,7 @@ paths:
       tags:
         - user
       summary: create a user
+      description: Create a local user. Only allowed when local authentication is enabled.
       operationId: createUser
       requestBody:
         description: detailed information about the user

--- a/src/resources/api/openapi.yaml
+++ b/src/resources/api/openapi.yaml
@@ -8,6 +8,60 @@ servers:
   - url: /api/v1
 
 paths:
+
+  /auth:
+    get: 
+      tags:
+        - auth
+      summary: get authentication config
+      operationId: getAuth
+      responses:
+        200:
+          description: authentication config
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  local:
+                    type: object
+                    properties:
+                      enabled: 
+                        type: boolean
+                  proxy:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+
+  /auth/local:
+    post:
+      tags:
+        - auth
+      summary: get a token from the local provider
+      description: get a token by providing username and password to the local authentication provider
+      requestBody:
+        description: username and password
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocalAuthenticationRequest"
+        required: true
+      responses:
+        200:
+          $ref: '#/components/responses/AuthenticationResponse'
+
+  /auth/proxy:
+    post:
+      tags: 
+        - auth
+      summary: get a token from the proxy provider
+      description: get a token by sending an empty request to the proxy provider
+      responses:
+        200:
+          $ref: '#/components/responses/AuthenticationResponse'
+
+
   /user:
     get:
       tags:
@@ -45,27 +99,21 @@ paths:
                 $ref: "#/components/schemas/User"
   /user/token:
     post:
+      deprecated: true
       tags:
         - user
-      summary: create an authentication token
-      operationId: createAuthenticationToken
+      summary: use `/auth/local` instead! 
+      description: just used for backwards compatibility
       requestBody:
         description: username and password
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserAuthenticationRequest"
+              $ref: "#/components/schemas/LocalAuthenticationRequest"
         required: true
       responses:
         200:
-          description: detailed information about the new user
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  token:
-                    type: string
+          $ref: '#/components/responses/AuthenticationResponse'
 
   /group:
     get:
@@ -242,6 +290,15 @@ paths:
 
 components:
   schemas:
+    LocalAuthenticationRequest:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+      required: [username, password]
+
     User:
       type: object
       properties:
@@ -264,15 +321,6 @@ components:
         password:
           type: string
       required: [username, nickname, password]
-
-    UserAuthenticationRequest:
-      type: object
-      properties:
-        username:
-          type: string
-        password:
-          type: string
-      required: [username, password]
 
     Group:
       type: object
@@ -356,6 +404,18 @@ components:
         description:
           type: string
           example: "Bread"
+
+  responses:
+    AuthenticationResponse:
+      description: the token
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              token:
+                type: string
+                format: jwt
 
   parameters:
     groupId:

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,0 +1,84 @@
+use crate::guards;
+use crate::services::authentication::AuthenticationService;
+use ::serde::{Deserialize, Serialize};
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use rocket::*;
+use std::sync::Arc;
+
+#[derive(Serialize)]
+struct AvailableProviders {
+    local: PublicLocalConfig,
+    proxy: PublicProxyConfig,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TokenResponse {
+    token: String,
+}
+
+// == local provider ==
+#[derive(Serialize)]
+struct PublicLocalConfig {
+    enabled: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct LocalRequest {
+    username: String,
+    password: String,
+}
+
+// == proxy provider ==
+#[derive(Serialize)]
+struct PublicProxyConfig {
+    enabled: bool,
+}
+
+#[get("/")]
+async fn available_providers(
+    authentication_service: &State<Arc<AuthenticationService>>,
+) -> Json<AvailableProviders> {
+    Json(AvailableProviders {
+        local: PublicLocalConfig {
+            enabled: authentication_service.local_enabled(),
+        },
+        proxy: PublicProxyConfig {
+            enabled: authentication_service.proxy_enabled(),
+        },
+    })
+}
+
+#[post("/local", data = "<local_request>")]
+async fn local(
+    local_request: Json<LocalRequest>,
+    authentication_service: &State<Arc<AuthenticationService>>,
+) -> Result<Json<TokenResponse>, Status> {
+    let res = authentication_service
+        .authenticate_local(&local_request.username, &local_request.password)
+        .await;
+
+    match res {
+        Some(token) => Ok(Json(TokenResponse { token })),
+        None => Err(Status::Unauthorized),
+    }
+}
+
+#[post("/proxy")]
+async fn proxy(
+    request_headers: guards::headers::RequestHeaders,
+    authentication_service: &State<Arc<AuthenticationService>>,
+) -> Result<Json<TokenResponse>, Status> {
+    let res = authentication_service
+        .authenticate_proxy(request_headers.headers)
+        .await;
+
+    match res {
+        Some(token) => Ok(Json(TokenResponse { token })),
+        None => Err(Status::Unauthorized),
+    }
+}
+
+pub fn routes() -> Vec<rocket::Route> {
+    routes![available_providers, local, proxy]
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod client;
 pub mod group;
 pub mod swagger;

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,4 +1,5 @@
 use crate::services::authentication::AuthenticationService;
+use crate::services::configuration::ConfigurationService;
 use crate::services::group::{Group, GroupService};
 use crate::services::user::{User, UserService};
 use ::serde::{Deserialize, Serialize};
@@ -62,9 +63,14 @@ async fn get_current_user(
 #[post("/", data = "<user_creation_request>")]
 async fn create_user(
     user_service: &State<Arc<UserService>>,
+    configuration_service: &State<Arc<ConfigurationService>>,
     group_service: &State<GroupService>,
     user_creation_request: Json<UserCreationRequest>,
 ) -> Result<Json<FullUser>, Status> {
+    if configuration_service.auth_local().is_none() {
+        return Err(Status::Forbidden);
+    }
+
     let res = user_service
         .create_user(
             user_creation_request.username.to_owned(),

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,9 +1,11 @@
+use crate::services::authentication::AuthenticationService;
 use crate::services::group::{Group, GroupService};
 use crate::services::user::{User, UserService};
 use ::serde::{Deserialize, Serialize};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::*;
+use std::sync::Arc;
 
 #[derive(Deserialize, Serialize)]
 pub struct UserCreationRequest {
@@ -59,12 +61,10 @@ async fn get_current_user(
 
 #[post("/", data = "<user_creation_request>")]
 async fn create_user(
-    user_service: &State<UserService>,
+    user_service: &State<Arc<UserService>>,
     group_service: &State<GroupService>,
     user_creation_request: Json<UserCreationRequest>,
 ) -> Result<Json<FullUser>, Status> {
-    let user_service = user_service as &UserService;
-    let group_service = group_service as &GroupService;
     let res = user_service
         .create_user(
             user_creation_request.username.to_owned(),
@@ -81,20 +81,19 @@ async fn create_user(
 
 #[post("/token", data = "<user_authentication_request>")]
 async fn token(
-    user_service: &State<UserService>,
+    authentication_service: &State<Arc<AuthenticationService>>,
     user_authentication_request: Json<UserAuthenticationRequest>,
 ) -> Result<Json<TokenResponse>, Status> {
-    let user_service = user_service as &UserService;
-    let res = user_service
-        .create_user_token(
-            user_authentication_request.username.to_owned(),
-            user_authentication_request.password.to_owned(),
+    let res = authentication_service
+        .authenticate_local(
+            &user_authentication_request.username,
+            &user_authentication_request.password,
         )
         .await;
 
     match res {
-        Ok(token) => Ok(Json(TokenResponse { token })),
-        Err(()) => Err(Status::Unauthorized),
+        Some(token) => Ok(Json(TokenResponse { token })),
+        None => Err(Status::Unauthorized),
     }
 }
 

--- a/src/services/authentication.rs
+++ b/src/services/authentication.rs
@@ -1,0 +1,130 @@
+use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+use rocket::serde::{Deserialize, Serialize};
+use sea_orm::*;
+use std::{collections::HashMap, process, sync::Arc};
+
+use super::{configuration::ConfigurationService, user::UserService};
+
+#[derive(Debug)]
+pub struct AuthenticationService {
+    db: Arc<DatabaseConnection>,
+    configuration_service: Arc<ConfigurationService>,
+    user_service: Arc<UserService>,
+}
+
+#[derive(Debug)]
+pub enum AuthenticationError {
+    InvalidToken,
+    MissingToken,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JwtClaims {
+    pub id: String,
+    iss: String,
+    exp: usize,
+}
+
+impl AuthenticationService {
+    pub fn new(
+        db: Arc<DatabaseConnection>,
+        configuration_service: Arc<ConfigurationService>,
+        user_service: Arc<UserService>,
+    ) -> AuthenticationService {
+        // make sure, we have at least one working provider
+        let new = AuthenticationService {
+            db: db,
+            configuration_service: configuration_service,
+            user_service: user_service,
+        };
+
+        if !new._config_valid() {
+            process::exit(1);
+        }
+
+        new
+    }
+
+    pub fn local_enabled(&self) -> bool {
+        match self.configuration_service.auth_local() {
+            Some(_) => true,
+            None => false,
+        }
+    }
+
+    pub async fn authenticate_local(&self, username: &str, password: &str) -> Option<String> {
+        self.configuration_service.auth_local()?;
+
+        Some(
+            self.generate_jwt(
+                self.user_service
+                    .check_username_and_password(username, password)
+                    .await?,
+            ),
+        )
+    }
+
+    pub fn proxy_enabled(&self) -> bool {
+        match self.configuration_service.auth_proxy() {
+            Some(_) => true,
+            None => false,
+        }
+    }
+
+    pub async fn authenticate_proxy(&self, headers: HashMap<String, String>) -> Option<String> {
+        let config = self.configuration_service.auth_proxy()?;
+
+        // TODO
+        Some("bla".to_owned())
+    }
+
+    fn _config_valid(&self) -> bool {
+        if let Some(c) = self.configuration_service.auth_proxy() {
+            if c.headers_username.is_none() {
+                println!("Error: You have enabled proxy authentication but not specified the username header!");
+                return false;
+            }
+            return true;
+        }
+
+        if self.local_enabled() {
+            return true;
+        }
+
+        println!("Error: at least one authentication provider must be enabled!");
+        false
+    }
+
+    pub async fn validate_jwt(
+        &self,
+        token: String,
+    ) -> Result<JwtClaims, jsonwebtoken::errors::Error> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_issuer(&["de:itsblue:money-balancer"]);
+        validation.validate_exp = false;
+
+        let token = jsonwebtoken::decode::<JwtClaims>(
+            &token,
+            &DecodingKey::from_secret(self.configuration_service.jwt_secret().as_bytes()),
+            &validation,
+        )?;
+
+        Ok(token.claims)
+    }
+
+    pub fn generate_jwt(&self, user_id: String) -> String {
+        let jwt = jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &JwtClaims {
+                id: user_id.to_owned(),
+                iss: "de:itsblue:money-balancer".to_string(),
+                exp: 0,
+            },
+            &jsonwebtoken::EncodingKey::from_secret(
+                self.configuration_service.jwt_secret().as_bytes(),
+            ),
+        );
+
+        jwt.unwrap()
+    }
+}

--- a/src/services/configuration.rs
+++ b/src/services/configuration.rs
@@ -1,46 +1,68 @@
 use std::process;
 
-use ::serde::Deserialize;
-use config::Config;
+use envconfig::Envconfig;
 
-#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
-struct JwtConfig {
-    secret: String,
+#[derive(Envconfig, Debug)]
+pub struct ProxyAuthConfig {
+    #[envconfig(from = "MONEYBALANCER_AUTH_PROXY_ENABLED", default = "false")]
+    enabled: bool,
+    #[envconfig(from = "MONEYBALANCER_AUTH_PROXY_HEADERS_USERNAME")]
+    pub headers_username: Option<String>,
+    #[envconfig(from = "MONEYBALANCER_AUTH_PROXY_HEADERS_NICKNAME")]
+    pub headers_nickname: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Envconfig, Debug)]
+struct LocalAuthConfig {
+    #[envconfig(from = "MONEYBALANCER_AUTH_LOCAL_ENABLED", default = "true")]
+    enabled: bool,
+}
+
+#[derive(Envconfig, Debug)]
+struct AuthConfig {
+    #[envconfig(nested = true)]
+    proxy: ProxyAuthConfig,
+    #[envconfig(nested = true)]
+    local: LocalAuthConfig,
+}
+
+#[derive(Envconfig, Debug)]
 pub struct ConfigurationService {
-    jwt: JwtConfig,
+    #[envconfig(from = "MONEYBALANCER_JWT_SECRET")]
+    jwt_secret: String,
+
+    #[envconfig(nested = true)]
+    auth: AuthConfig,
 }
 
 impl ConfigurationService {
     pub fn new() -> ConfigurationService {
-        let res = Config::builder()
-            .add_source(
-                config::Environment::with_prefix("MONEYBALANCER")
-                    .try_parsing(true)
-                    .separator("_"),
-            )
-            .build()
-            .unwrap()
-            .try_deserialize::<ConfigurationService>();
+        let res = ConfigurationService::init_from_env();
 
         if let Ok(c) = res {
             return c;
         }
 
-        let error_message = match res.unwrap_err() {
-            config::ConfigError::NotFound(field) => field,
-            config::ConfigError::Message(m) => m,
-            _ => "unknown error".to_owned(),
-        };
-
-        println!("Error loading config: {}", error_message);
-        println!("Please make sure, you have set all required environment variables.");
+        println!("Error loading config:");
+        println!("{}", res.unwrap_err().to_string());
         process::exit(1);
     }
 
-    pub fn jwt_secret(&self) -> String {
-        self.jwt.secret.to_owned()
+    pub fn jwt_secret(&self) -> &str {
+        &self.jwt_secret
+    }
+
+    pub fn auth_local(&self) -> Option<()> {
+        match self.auth.local.enabled {
+            false => None,
+            true => Some(()),
+        }
+    }
+
+    pub fn auth_proxy(&self) -> Option<&ProxyAuthConfig> {
+        match self.auth.proxy.enabled {
+            false => None,
+            true => Some(&self.auth.proxy),
+        }
     }
 }

--- a/src/services/configuration.rs
+++ b/src/services/configuration.rs
@@ -1,4 +1,4 @@
-use std::process;
+use std::{env, process};
 
 use envconfig::Envconfig;
 
@@ -37,6 +37,8 @@ pub struct ConfigurationService {
 
 impl ConfigurationService {
     pub fn new() -> ConfigurationService {
+        ConfigurationService::_load_deprecated_variables();
+
         let res = ConfigurationService::init_from_env();
 
         if let Ok(c) = res {
@@ -63,6 +65,13 @@ impl ConfigurationService {
         match self.auth.proxy.enabled {
             false => None,
             true => Some(&self.auth.proxy),
+        }
+    }
+
+    // used for backwards compatibility
+    fn _load_deprecated_variables() {
+        if env::var("JWT_SECRET").is_ok() && env::var("MONEYBALANCER_JWT_SECRET").is_err() {
+            env::set_var("MONEYBALANCER_JWT_SECRET", env::var("JWT_SECRET").unwrap());
         }
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod authentication;
 pub mod configuration;
 pub mod group;
 pub mod user;

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -76,18 +76,22 @@ impl UserService {
         }
     }
 
-    pub async fn get_user_by_id(&self, user_id: String) -> Result<User, ()> {
+    pub async fn get_user_by_id(&self, user_id: String) -> Option<User> {
         let user = model::user::Entity::find_by_id(user_id)
             .one(self.db.as_ref())
             .await
-            .expect("Failed to query user!");
+            .expect("Failed to query user!")?;
 
-        if let None = user {
-            return Err(());
-        }
+        Some(user.into())
+    }
 
-        let user = user.unwrap();
+    pub async fn get_user_by_username(&self, username: &str) -> Option<User> {
+        let user = model::user::Entity::find()
+            .filter(model::user::Column::Username.eq(username))
+            .one(self.db.as_ref())
+            .await
+            .expect("Failed to query user!")?;
 
-        Ok(user.into())
+        Some(user.into())
     }
 }


### PR DESCRIPTION
Fixes #3 

Will be implemented like this:
- The proxy authentication provider has to be configured to protect these routes:
  - `/api/v1/auth/proxy`
  - `/#/login/proxy`
  - Everything else is protected by the regular JWT authentication
- The client will redirect to `/#/login/proxy` to trigger the login
- The client will get a JWT token by sending an empty POST-request to `/api/v1/auth/proxy`.
- This allows an instance to use not only proxy authentication but also another one like local or oidc

Todo:
- [X] server
- [x] client
- [x] backward compatibility for `JWT_SECRET` env